### PR TITLE
Fix Gradle 8 compatibility: replace deprecated destinationDir property

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -149,7 +149,7 @@ afterEvaluate { project ->
         def javaCompileTask = variant.javaCompileProvider.get()
 
         task "jar${name}"(type: Jar, dependsOn: javaCompileTask) {
-            from javaCompileTask.destinationDir
+            from javaCompileTask.destinationDirectory
         }
     }
 


### PR DESCRIPTION
This PR fixes Android build failures on Gradle 8.x (React Native 0.71+).

## The problem
`destinationDir` was deprecated in Gradle 7 and removed in Gradle 8, causing builds to fail with: "Could not get unknown property 'destinationDir' for task... of type org.gradle.api.tasks.compile.JavaCompile"

## The fix
Replace `destinationDir` with `destinationDirectory`, which has been available since Gradle 6.1 (backward compatible).

## References
[Gradle 7 to 8 migration guide](https://docs.gradle.org/8.0/userguide/upgrading_version_7.html#compile_task_wiring)
[destinatoinDirectory API docs](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.tasks.compile/-abstract-compile/destination-directory.html)

This is a small one line fix so I thought I'd just create a PR rather than opening an issue. Thank you for this library!